### PR TITLE
feat: add coordinate parser and human player input handler

### DIFF
--- a/src/tictactoe_cli/ui/input.py
+++ b/src/tictactoe_cli/ui/input.py
@@ -1,0 +1,35 @@
+"""Coordinate parsing and validation for human input (a1-c3 format)."""
+
+from __future__ import annotations
+
+_COL_MAP: dict[str, int] = {"a": 0, "b": 1, "c": 2}
+_VALID_ROWS: set[str] = {"1", "2", "3"}
+
+
+def parse_coordinate(raw: str) -> int:
+    """Convert a chess-style coordinate to a cell index (0-8).
+
+    Args:
+        raw: A 2-character string like "a1", "B2", "c3".
+
+    Returns:
+        Cell index in 0-8 range (row-major order).
+
+    Raises:
+        ValueError: If the coordinate is invalid.
+    """
+    if len(raw) != 2:
+        msg = f"Expected 2 characters, got {len(raw)}: {raw!r}"
+        raise ValueError(msg)
+
+    col_char, row_char = raw[0].lower(), raw[1]
+
+    if col_char not in _COL_MAP:
+        msg = f"Invalid column {raw[0]!r}, expected a/b/c"
+        raise ValueError(msg)
+
+    if row_char not in _VALID_ROWS:
+        msg = f"Invalid row {raw[1]!r}, expected 1/2/3"
+        raise ValueError(msg)
+
+    return (int(row_char) - 1) * 3 + _COL_MAP[col_char]

--- a/src/tictactoe_cli/ui/input.py
+++ b/src/tictactoe_cli/ui/input.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+_BOARD_SIZE = 3
 _COL_MAP: dict[str, int] = {"a": 0, "b": 1, "c": 2}
 _VALID_ROWS: set[str] = {"1", "2", "3"}
 
@@ -32,4 +33,4 @@ def parse_coordinate(raw: str) -> int:
         msg = f"Invalid row {raw[1]!r}, expected 1/2/3"
         raise ValueError(msg)
 
-    return (int(row_char) - 1) * 3 + _COL_MAP[col_char]
+    return (int(row_char) - 1) * _BOARD_SIZE + _COL_MAP[col_char]

--- a/src/tictactoe_cli/ui/players.py
+++ b/src/tictactoe_cli/ui/players.py
@@ -6,24 +6,19 @@ from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.prompt import Prompt
-from tic_tac_toe_3x3.game.players import Player  # type: ignore[import-untyped]
+from tic_tac_toe_3x3.game.players import Player
 
 from tictactoe_cli.ui.input import parse_coordinate
 
 if TYPE_CHECKING:
-    from tic_tac_toe_3x3.logic.models import GameState, Move
+    from tic_tac_toe_3x3.logic.models import GameState, Mark, Move
 
 
 class HumanPlayer(Player):  # type: ignore[misc]
     """A human player that reads moves from terminal input."""
 
-    def __init__(
-        self,
-        *args: object,
-        console: Console | None = None,
-        **kwargs: object,
-    ) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+    def __init__(self, mark: Mark, *, console: Console | None = None) -> None:
+        super().__init__(mark)
         self._console = console or Console()
 
     def get_move(self, game_state: GameState) -> Move | None:

--- a/src/tictactoe_cli/ui/players.py
+++ b/src/tictactoe_cli/ui/players.py
@@ -1,0 +1,47 @@
+"""Human player implementation using Rich terminal prompts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.prompt import Prompt
+from tic_tac_toe_3x3.game.players import Player  # type: ignore[import-untyped]
+
+from tictactoe_cli.ui.input import parse_coordinate
+
+if TYPE_CHECKING:
+    from tic_tac_toe_3x3.logic.models import GameState, Move
+
+
+class HumanPlayer(Player):  # type: ignore[misc]
+    """A human player that reads moves from terminal input."""
+
+    def __init__(
+        self,
+        *args: object,
+        console: Console | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._console = console or Console()
+
+    def get_move(self, game_state: GameState) -> Move | None:
+        """Prompt the user for a move and return it.
+
+        Keeps asking until a valid coordinate for an empty cell is entered.
+        Returns None if no possible moves remain.
+        """
+        if not game_state.possible_moves:
+            return None
+
+        while True:
+            raw = Prompt.ask(
+                f"[yellow]Хід {game_state.current_mark} (a1-c3)[/yellow]",
+                console=self._console,
+            )
+            try:
+                index = parse_coordinate(raw)
+                return game_state.make_move_to(index)
+            except ValueError as exc:
+                self._console.print(f"[red]{exc}[/red]")

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,65 @@
+"""Tests for coordinate parsing and validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tictactoe_cli.ui.input import parse_coordinate
+
+
+class TestValidCoordinates:
+    """All 9 valid coordinates must map to correct cell indices."""
+
+    @pytest.mark.parametrize(
+        ("coord", "expected"),
+        [
+            ("a1", 0),
+            ("b1", 1),
+            ("c1", 2),
+            ("a2", 3),
+            ("b2", 4),
+            ("c2", 5),
+            ("a3", 6),
+            ("b3", 7),
+            ("c3", 8),
+        ],
+    )
+    def test_lowercase(self, coord: str, expected: int) -> None:
+        assert parse_coordinate(coord) == expected
+
+    @pytest.mark.parametrize(
+        ("coord", "expected"),
+        [
+            ("A1", 0),
+            ("B2", 4),
+            ("C3", 8),
+            ("A3", 6),
+            ("C1", 2),
+        ],
+    )
+    def test_uppercase(self, coord: str, expected: int) -> None:
+        assert parse_coordinate(coord) == expected
+
+
+class TestInvalidCoordinates:
+    """Invalid input must raise ValueError."""
+
+    @pytest.mark.parametrize(
+        "coord",
+        [
+            "",
+            "a",
+            "1",
+            "d1",
+            "a4",
+            "a0",
+            "ab",
+            "11",
+            "abc",
+            " a1",
+            "a1 ",
+        ],
+    )
+    def test_raises_value_error(self, coord: str) -> None:
+        with pytest.raises(ValueError):
+            parse_coordinate(coord)


### PR DESCRIPTION
Implement parse_coordinate() for chess-style a1-c3 input mapping to cell indices 0-8 (case-insensitive, with validation). Add HumanPlayer that prompts via Rich and retries on invalid input. Includes 25 parameterized tests covering all valid coordinates and edge cases.

 Task 04 виконана:                                      
                                                         
  Створено:                                              
  - src/tictactoe_cli/ui/input.py — parse_coordinate(raw:
   str) -> int з маппінгом a1→0...c3→8, case-insensitive,
   з валідацією                                          
  - src/tictactoe_cli/ui/players.py — HumanPlayer(Player)
   з Rich prompt, retry-loop при невалідному введенні    
  - tests/test_input.py — 25 параметризованих тестів (14 
  valid + 11 invalid координат)   